### PR TITLE
Change babylon-provider to template

### DIFF
--- a/integration/anarchy-operator/babylon-provider.yaml
+++ b/integration/anarchy-operator/babylon-provider.yaml
@@ -1,81 +1,93 @@
 ---
-apiVersion: poolboy.gpte.redhat.com/v1
-kind: ResourceProvider
+apiVersion: template.openshift.io/v1
+kind: Template
 metadata:
-  name: babylon
-  namespace: poolboy
-spec:
-  default:
-    spec:
-      desiredState: started
-  match:
-    apiVersion: anarchy.gpte.redhat.com/v1
-    kind: AnarchySubject
-    metadata:
-      annotations:
-        poolboy.gpte.redhat.com/resource-provider-name: babylon
-  matchIgnore:
-  - /spec/desiredState
-  override:
-    metadata:
-      namespace: anarchy-operator
-    spec:
-      vars:
-        babylon_user_email: >-
-          {{: requester_identity.extra.email | default(None) if requester_identity else None :}}
-        babylon_user_fullname: >-
-          {{: requester_identity.extra.name | default(None) if requester_identity else None :}}
-        babylon_username: >-
-          {{: requester_user.metadata.name | default(None) if requester_user else None :}}
-        job_vars:
-          guid: >-
-            {{: resource_handle.metadata.name[-5:] :}}
-  updateFilters:
-  - pathMatch: /spec/desiredState
-  validation:
-    openAPIV3Schema:
-      type: object
-      additionalProperties: false
-      required:
-      - apiVersion
-      - kind
-      - metadata
-      - spec
-      properties:
-        apiVersion:
-          type: string
-          enum:
-          - anarchy.gpte.redhat.com/v1
-        kind:
-          type: string
-          enum:
-          - AnarchySubject
-        metadata:
-          type: object
-          additionalProperties: false
-          properties:
-            annotations:
-              additionalProperties:
+  annotations:
+    description: poolboy resourceprovider deploy
+  name: poolboy-resourceprovider-deploy
+
+parameters:
+- name: NAMESPACE
+  value: poolboy
+
+
+  apiVersion: poolboy.gpte.redhat.com/v1
+  kind: ResourceProvider
+  metadata:
+    name: babylon
+    namespace: poolboy
+  spec:
+    default:
+      spec:
+        desiredState: started
+    match:
+      apiVersion: anarchy.gpte.redhat.com/v1
+      kind: AnarchySubject
+      metadata:
+        annotations:
+          poolboy.gpte.redhat.com/resource-provider-name: babylon
+    matchIgnore:
+    - /spec/desiredState
+    override:
+      metadata:
+        namespace: anarchy-operator
+      spec:
+        vars:
+          babylon_user_email: >-
+            {{: requester_identity.extra.email | default(None) if requester_identity else None :}}
+          babylon_user_fullname: >-
+            {{: requester_identity.extra.name | default(None) if requester_identity else None :}}
+          babylon_username: >-
+            {{: requester_user.metadata.name | default(None) if requester_user else None :}}
+          job_vars:
+            guid: >-
+              {{: resource_handle.metadata.name[-5:] :}}
+    updateFilters:
+    - pathMatch: /spec/desiredState
+    validation:
+      openAPIV3Schema:
+        type: object
+        additionalProperties: false
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - spec
+        properties:
+          apiVersion:
+            type: string
+            enum:
+            - anarchy.gpte.redhat.com/v1
+          kind:
+            type: string
+            enum:
+            - AnarchySubject
+          metadata:
+            type: object
+            additionalProperties: false
+            properties:
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              generateName:
                 type: string
-              type: object
-            generateName:
-              type: string
-            labels:
-              additionalProperties:
+              labels:
+                additionalProperties:
+                  type: string
+                type: object
+          spec:
+            type: object
+            required:
+            - governor
+            additionalProperties: false
+            properties:
+              desiredState:
+                enum:
+                - started
+                - stopped
                 type: string
-              type: object
-        spec:
-          type: object
-          required:
-          - governor
-          additionalProperties: false
-          properties:
-            desiredState:
-              enum:
-              - started
-              - stopped
-              type: string
-            governor:
-              type: string
-            vars:
-              type: object
+              governor:
+                type: string
+              vars:
+                type: object

--- a/integration/anarchy-operator/babylon-provider.yaml
+++ b/integration/anarchy-operator/babylon-provider.yaml
@@ -9,13 +9,14 @@ metadata:
 parameters:
 - name: NAMESPACE
   value: poolboy
-
+- name: ANARCHY_NAMESPACE
+  value: anarchy-operator
 
   apiVersion: poolboy.gpte.redhat.com/v1
   kind: ResourceProvider
   metadata:
     name: babylon
-    namespace: poolboy
+    namespace: "${NAMESPACE}" 
   spec:
     default:
       spec:
@@ -30,7 +31,7 @@ parameters:
     - /spec/desiredState
     override:
       metadata:
-        namespace: anarchy-operator
+        namespace: "${ANARCHY_NAMESPACE}"
       spec:
         vars:
           babylon_user_email: >-

--- a/integration/anarchy-operator/babylon-provider.yaml
+++ b/integration/anarchy-operator/babylon-provider.yaml
@@ -5,14 +5,8 @@ metadata:
   annotations:
     description: poolboy resourceprovider deploy
   name: poolboy-resourceprovider-deploy
-
-parameters:
-- name: NAMESPACE
-  value: poolboy
-- name: ANARCHY_NAMESPACE
-  value: anarchy-operator
-
-  apiVersion: poolboy.gpte.redhat.com/v1
+objects:
+- apiVersion: poolboy.gpte.redhat.com/v1
   kind: ResourceProvider
   metadata:
     name: babylon
@@ -92,3 +86,8 @@ parameters:
                 type: string
               vars:
                 type: object
+parameters:
+- name: NAMESPACE
+  value: poolboy
+- name: ANARCHY_NAMESPACE
+  value: anarchy-operator


### PR DESCRIPTION
This changes `babylon-provider.yml` to a template so that we can parameterize the `ANARCHY_NAMESPACE`. Previously this was hard-coded and wouldn't work if anarchy was deployed to a different namespace.