### PR TITLE
Use helm for installing poolboy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -85,6 +85,25 @@ oc process \
 | oc apply -n poolboy -f -
 ----
 
+### Using Helm
+
+Helm v3 support only.
+
+. Clone this repo to your local workstation and change directory:
++
+----
+git clone https://github.com/redhat-cop/poolboy.git
+cd poolboy
+----
+
+. Install with Helm
++
+----
+helm template helm | oc apply -f -
+----
+
+CAUTION: The anarchy namespace must already exist as we will create objects in that namespace. The default is `anarchy-operator` but can be configured in `value.yaml` or with `--set anarchy.namespace=<anarchy namespace>` above.
+
 ## Credits
 
 Poolboy logo is original art by Lara Ditkoff

--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: poolboy
+description: A Helm chart for poolboy
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: v0.2.14

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,93 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "poolboy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "poolboy.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "poolboy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "poolboy.labels" -}}
+helm.sh/chart: {{ include "poolboy.chart" . }}
+{{ include "poolboy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "poolboy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "poolboy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "poolboy.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "poolboy.name" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the namespace to use
+*/}}
+{{- define "poolboy.namespaceName" -}}
+{{- if .Values.namespace.create -}}
+    {{ default (include "poolboy.name" .) .Values.namespace.name }}
+{{- else -}}
+    {{ default "default" .Values.namespace.name }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Create the operator domain to use
+*/}}
+{{- define "poolboy.operatorDomain" -}}
+{{- if .Values.operator_domain.generate -}}
+    {{ default (printf "%s.gpte.redhat.com" (include "poolboy.name" .)) .Values.operator_domain.name }}
+{{- else -}}
+    {{ default "default" .Values.operator_domain.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the image to deploy
+*/}}
+{{- define "poolboy.image" -}}
+{{- printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tagOverride) -}}
+{{- end -}}

--- a/helm/templates/anarchy-integration.yaml
+++ b/helm/templates/anarchy-integration.yaml
@@ -1,0 +1,148 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "poolboy.name" . }}:{{ .Values.anarchy.namespace }}:{{ .Values.anarchy.service }}
+rules:
+- apiGroups:
+  - {{ include "poolboy.operatorDomain" . }}
+  resources:
+  - resourceclaims
+  - resourcehandles
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "poolboy.name" . }}:{{ .Values.anarchy.namespace }}:{{ .Values.anarchy.service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "poolboy.name" . }}:{{ .Values.anarchy.namespace }}:{{ .Values.anarchy.service }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ .Values.anarchy.namespace }}
+  name: {{ .Values.anarchy.service }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "poolboy.namespaceName" . }}:{{ include "poolboy.name" . }}
+  namespace: {{ .Values.anarchy.namespace }}
+rules:
+- apiGroups:
+  - {{ .Values.anarchy.domain }}
+  resources:
+  - anarchysubjects
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+  - update
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.anarchy.namespace }}:{{ include "poolboy.namespaceName" . }}:{{ include "poolboy.name" . }}
+  namespace: {{ .Values.anarchy.namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "poolboy.namespaceName" . }}:{{ include "poolboy.name" . }}
+subjects:
+- kind: ServiceAccount
+  namespace: {{ include "poolboy.namespaceName" . }}
+  name: {{ include "poolboy.name" . }}
+---
+apiVersion: poolboy.gpte.redhat.com/v1
+kind: ResourceProvider
+metadata:
+  name: babylon
+  namespace: {{ include "poolboy.namespaceName" . }}
+spec:
+  default:
+    spec:
+      vars:
+        desired_state: started
+  match:
+    apiVersion: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    metadata:
+      annotations:
+        poolboy.gpte.redhat.com/resource-provider-name: babylon
+  matchIgnore:
+  - /spec/vars/current_state
+  - /spec/vars/desired_state
+  override:
+    metadata:
+      namespace: {{ .Values.anarchy.namespace }}
+    spec:
+      vars:
+        babylon_user_email: >-
+          {{`{{: requester_identity.extra.email | default(None) if requester_identity else None :}}`}}
+        babylon_user_fullname: >-
+          {{`{{: requester_identity.extra.name | default(None) if requester_identity else None :}}`}}
+        babylon_username: >-
+          {{`{{: requester_user.metadata.name | default(None) if requester_user else None :}}`}}
+        job_vars:
+          guid: >-
+            {{`{{: resource_handle.metadata.name[5:]
+             if resource_handle.metadata.name.startswith('guid-')
+             else resource_handle.metadata.name :}}`}}
+  updateFilters:
+  - pathMatch: /spec/vars/desired_state
+  validation:
+    openAPIV3Schema:
+      type: object
+      additionalProperties: false
+      required:
+      - apiVersion
+      - kind
+      - metadata
+      - spec
+      properties:
+        apiVersion:
+          type: string
+          enum:
+          - anarchy.gpte.redhat.com/v1
+        kind:
+          type: string
+          enum:
+          - AnarchySubject
+        metadata:
+          type: object
+          additionalProperties: false
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              type: object
+            generateName:
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              type: object
+        spec:
+          type: object
+          required:
+          - governor
+          additionalProperties: false
+          properties:
+            governor:
+              type: string
+            vars:
+              type: object
+              properties:
+                desired_state:
+                  enum:
+                  - started
+                  - stopped
+                  type: string

--- a/helm/templates/crds.yaml
+++ b/helm/templates/crds.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.crds.create -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resourceclaims.{{ include "poolboy.operatorDomain" . }}
+spec:
+  group: {{ include "poolboy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: resourceclaims
+    singular: resourceclaim
+    kind: ResourceClaim
+    shortNames: []
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcehandles.{{ include "poolboy.operatorDomain" . }}
+spec:
+  group: {{ include "poolboy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: resourcehandles
+    singular: resourcehandle
+    kind: ResourceHandle
+    shortNames: []
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resourceproviders.{{ include "poolboy.operatorDomain" . }}
+spec:
+  group: {{ include "poolboy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: resourceproviders
+    singular: resourceprovider
+    kind: ResourceProvider
+    shortNames: []
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcepools.{{ include "poolboy.operatorDomain" . }}
+spec:
+  group: {{ include "poolboy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: resourcepools
+    singular: resourcepool
+    kind: ResourcePool
+    shortNames: []
+  subresources:
+    status: {}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "poolboy.name" . }}
+  namespace: {{ include "poolboy.namespaceName" . }}
+  labels:
+    {{- include "poolboy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "poolboy.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{- include "poolboy.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "poolboy.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: manager
+          env:
+          - name: OPERATOR_DOMAIN
+            value: {{ include "poolboy.operatorDomain" . }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ include "poolboy.image" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      restartPolicy: Always
+      securityContext: {}
+      serviceAccountName: {{ include "poolboy.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.namespace.create -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "poolboy.namespaceName" . }}
+  labels:
+    {{- include "poolboy.labels" . | nindent 4 }}
+  annotations:
+    openshift-provision/action: create
+{{- end -}}

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -1,0 +1,102 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "poolboy.name" . }}-aggregate-to-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - {{ include "poolboy.operatorDomain" . }}
+  resources:
+  - resourceclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "poolboy.name" . }}-aggregate-to-edit
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+rules:
+- apiGroups:
+  - {{ include "poolboy.operatorDomain" . }}
+  resources:
+  - resourceclaims
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "poolboy.name" . }}
+rules:
+- apiGroups:
+  - {{ include "poolboy.operatorDomain" . }}
+  resources:
+  - resourceproviders
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - {{ include "poolboy.operatorDomain" . }}
+  resources:
+  - resourceclaims
+  - resourceclaims/status
+  - resourcehandles
+  - resourcepools
+  - resourcepools/status
+  - resourceproviders/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - user.openshift.io
+  resources:
+  - users
+  - identities
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "poolboy.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "poolboy.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "poolboy.name" . }}
+  namespace: {{ include "poolboy.namespaceName" . }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "poolboy.name" . }}
+  namespace: {{ include "poolboy.namespaceName" . }}
+  labels:
+    {{- include "poolboy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  {{- with .Values.service.ports }}
+  ports:
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+  selector:
+    {{- include "poolboy.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "poolboy.serviceAccountName" . }}
+  namespace: {{ include "poolboy.namespaceName" . }}
+  labels:
+    {{- include "poolboy.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,84 @@
+# Default values for ..
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+namespace:
+  # Specifies whether a namespace should be created
+  create: true
+  # The name of the namespace to use.
+  # If not set and create is true, a name is generated using the name template
+  name:
+
+# Installing CustomResourceDefinitions requires elevated privileges (typically cluster-admin)
+crds:
+  create: true
+
+operator_domain:
+  # Specifies whether the operator domain should be generatedi (default: poolboy.gpte.redhat.com)
+  generate: true
+  # The name of the operator domain to use
+  # If not set and create is true, a name is generated using the operatorDomain template
+  name:
+
+anarchy:
+  domain: anarchy.gpte.redhat.com
+  namespace: anarchy-operator
+  service: anarchy-operator
+
+replicaCount: 1
+
+image:
+  repository: quay.io/redhat-cop/poolboy
+  pullPolicy: Always
+  tagOverride: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8000
+  ports:
+  - name: metrics
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
The Helm chart uses the `appVersion` in the `Chart.yaml` as the default image(s) tag. This can be overridden in the `value.yaml` file.
I'm also wondering if we now should remove old install and deploy instructions and files and complete the move to Helm?