### PR TITLE
Remove typo from resourceclaim CRD

### DIFF
--- a/helm/templates/crds/resourceclaims.yaml
+++ b/helm/templates/crds/resourceclaims.yaml
@@ -100,8 +100,6 @@ spec:
                         type: string
                       namespace:
                         type: string
-                        state:
-                          type: object
                   state:
                     description: Resource state synchronized from managed resource
                     type: object


### PR DESCRIPTION
I think this is a copy pasta issue.
The deployed resourceclaim CRD actually strips these two lines and the only reason I've noticed this is because ArgoCD keeps trying to add them back.

This is with `v0.3.7` of the resourceclaim CRD on an OCP 4.5 cluster, note that the `state.type` is missing.
```
❯ oc get crd resourceclaims.poolboy.gpte.redhat.com -oyaml|yq r - 'spec.versions[0].schema.openAPIV3Schema.properties.status.properties.resources'
description: Status of resources managed for this claim
items:
  properties:
    provider:
      description: ResourceProvider reference for provider managing this resource
      properties:
        apiVersion:
          type: string
        kind:
          type: string
        name:
          type: string
        namespace:
          type: string
      type: object
    state:
      description: Resource state synchronized from managed resource
      type: object
  type: object
type: array
```