### PR TITLE
Allow missing type in openAPIV3Schema

### DIFF
--- a/operator/gpte/util.py
+++ b/operator/gpte/util.py
@@ -147,7 +147,7 @@ def defaults_from_schema(schema):
     for prop, property_schema in schema.get('properties', {}).items():
         if 'default' in property_schema and prop not in obj:
             obj[prop] = property_schema['default']
-        if property_schema['type'] == 'object':
+        if property_schema.get('type') == 'object':
             defaults = defaults_from_schema(property_schema)
             if defaults:
                 if not prop in obj:


### PR DESCRIPTION
Missing type is valid and means that any type is permitted.