### PR TITLE
Fixes for pool lifespan behavior

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/redhat-cop/python-kopf-s2i:v1.33
+FROM quay.io/redhat-cop/python-kopf-s2i:v1.34
 
 USER root
 

--- a/build-template.yaml
+++ b/build-template.yaml
@@ -14,7 +14,7 @@ parameters:
 - name: GIT_REF
   value: main
 - name: KOPF_S2I_IMAGE
-  value: quay.io/redhat-cop/python-kopf-s2i:v1.33
+  value: quay.io/redhat-cop/python-kopf-s2i:v1.34
 - name: PYTHON_S2I_IMAGE
   value: registry.access.redhat.com/ubi8/python-38:latest
 

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -26,7 +26,7 @@ components:
       value: "5"
     - name: OPERATOR_DOMAIN
       value: poolboy.dev.local
-    image: quay.io/redhat-cop/python-kopf-s2i:v1.33
+    image: quay.io/redhat-cop/python-kopf-s2i:v1.34
     mountSources: true
     sourceMapping: /tmp/projects
 commands:


### PR DESCRIPTION
Prevent ResourceClaims from binding to ResourceHandles pending delete.
Explicitly list properties from ResourcePool that propagate to ResourceHandle lifespan.
Bump kopf to v1.34.