### PR TITLE
Add resource name in generated resources list

### DIFF
--- a/helm/crds/resourceproviders.yaml
+++ b/helm/crds/resourceproviders.yaml
@@ -209,6 +209,10 @@ spec:
                             fields to specific numeric ranges.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+              resourceName:
+                description: >-
+                  Name to apply to resource list entry when resources list is generated.
+                type: string
               resourceRequiresClaim:
                 description: >-
                   Flag to indicate that creation of resource for handle should waint until a claim

--- a/helm/templates/crds/resourceproviders.yaml
+++ b/helm/templates/crds/resourceproviders.yaml
@@ -210,6 +210,10 @@ spec:
                             fields to specific numeric ranges.
                           type: object
                           x-kubernetes-preserve-unknown-fields: true
+              resourceName:
+                description: >-
+                  Name to apply to resource list entry when resources list is generated.
+                type: string
               resourceRequiresClaim:
                 description: >-
                   Flag to indicate that creation of resource for handle should waint until a claim

--- a/operator/resourceclaim.py
+++ b/operator/resourceclaim.py
@@ -459,13 +459,8 @@ class ResourceClaim:
                     raise
 
     async def assign_resource_providers(self, logger) -> None:
-        """
-        Assign resource providers in status.
-        """
-        if self.has_resource_provider:
-            resources = await self.get_resources_from_provider()
-        else:
-            resources = self.spec.get('resources', None)
+        """Assign resource providers in status for ResourceClaim with resources listed in spec."""
+        resources = self.spec.get('resources', None)
 
         if not resources:
             raise kopf.TemporaryError(f"{self} has no resources", delay=600)
@@ -900,6 +895,7 @@ class ResourceClaim:
                 )
                 patch['resources'] = [
                     {
+                        "name": resource['name'],
                         "provider": resource['provider'],
                     } for resource in resources
                 ]

--- a/test/roles/poolboy_test_simple/tasks/test-parameters-02.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test-parameters-02.yaml
@@ -102,6 +102,7 @@
               type: integer
               default: 0
               minimum: 0
+        resourceName: binder
         template:
           definition:
             spec:
@@ -132,7 +133,6 @@
             stringvar: one
             numbervar: 1
 
-- fail:
 - name: Verify handling of ResourceClaim test-parameters-02-a
   kubernetes.core.k8s_info:
     api_version: "{{ poolboy_domain }}/v1"
@@ -141,11 +141,20 @@
     namespace: "{{ poolboy_test_namespace }}"
   register: r_get_resource_claim
   failed_when: >-
-    r_get_resource_claim.resources[0].status.resources[0].state is undefined
+    r_get_resource_claim.resources[0].status.resources[0].name != 'base-a' or
+    r_get_resource_claim.resources[0].status.resources[0].provider.name != 'test-parameters-02-base' or
+    r_get_resource_claim.resources[0].status.resources[0].state is undefined or
+    r_get_resource_claim.resources[0].status.resources[1].name != 'base-b' or
+    r_get_resource_claim.resources[0].status.resources[1].provider.name != 'test-parameters-02-base' or
+    r_get_resource_claim.resources[0].status.resources[1].state is undefined or
+    r_get_resource_claim.resources[0].status.resources[2].name != 'test-parameters-02-binder' or
+    r_get_resource_claim.resources[0].status.resources[2].provider.name != 'binder' or
+    r_get_resource_claim.resources[0].status.resources[2].state is undefined
   until: r_get_resource_claim is success
   delay: 1
   retries: 10
 
+- fail:
 - name: Save facts from for ResourceClaim test-parameters-02-a
   vars:
     __name: >-


### PR DESCRIPTION
This PR completes the feature set to allow ResourceClaim to use parameters rather than explicitly requesting definitions in `spec.template`.