### PR TITLE
Add status summary feature

### DIFF
--- a/helm/crds/resourceclaims.yaml
+++ b/helm/crds/resourceclaims.yaml
@@ -221,3 +221,8 @@ spec:
                     validationError:
                       description: Error message from resource provider.
                       type: string
+              summary:
+                description: >-
+                  Status summary from current resources state, generated from ResourceProvider configuration.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true

--- a/helm/crds/resourceproviders.yaml
+++ b/helm/crds/resourceproviders.yaml
@@ -218,6 +218,11 @@ spec:
                   Flag to indicate that creation of resource for handle should waint until a claim
                   is bound.
                 type: boolean
+              statusSummaryTemplate:
+                description: >-
+                  Object template for generating ResourceClaim status.summary from current state.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               template:
                 description: >-
                   Template settings for the ResourceProvider. Applied to override and defaults.

--- a/helm/templates/crds/resourceclaims.yaml
+++ b/helm/templates/crds/resourceclaims.yaml
@@ -222,4 +222,9 @@ spec:
                     validationError:
                       description: Error message from resource provider.
                       type: string
+              summary:
+                description: >-
+                  Status summary from current resources state, generated from ResourceProvider configuration.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
 {{- end -}}

--- a/helm/templates/crds/resourceproviders.yaml
+++ b/helm/templates/crds/resourceproviders.yaml
@@ -219,6 +219,11 @@ spec:
                   Flag to indicate that creation of resource for handle should waint until a claim
                   is bound.
                 type: boolean
+              statusSummaryTemplate:
+                description: >-
+                  Object template for generating ResourceClaim status.summary from current state.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               template:
                 description: >-
                   Template settings for the ResourceProvider. Applied to override and defaults.

--- a/operator/resourceprovider.py
+++ b/operator/resourceprovider.py
@@ -252,6 +252,10 @@ class ResourceProvider:
         return self.spec.get('resourceRequiresClaim', False)
 
     @property
+    def status_summary_template(self) -> Optional[Mapping]:
+        return self.spec.get('statusSummaryTemplate')
+
+    @property
     def template_enable(self):
         return self.spec.get('template', {}).get('enable', False)
 
@@ -427,6 +431,20 @@ class ResourceProvider:
         cmp_template = deepcopy(template)
         deep_merge(cmp_template, self.match)
         return template == cmp_template
+
+    def make_status_summary(self,
+        resource_claim: ResourceClaimT,
+    ) -> Mapping:
+        return recursive_process_template_strings(
+            self.status_summary_template,
+            variables = {
+                **self.vars,
+                **resource_claim.parameter_values,
+                "resource_claim": resource_claim,
+                "resource_provider": self,
+                "resources": resource_claim.status_resources,
+            }
+        )
 
     def processed_template(self,
         parameter_values: Mapping,

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ pytimeparse==1.1.8
 PyYAML==5.4.1
 requests==2.26.0
 urllib3==1.26.6
-Werkzeug==1.0.1

--- a/test/roles/poolboy_test_simple/tasks/test-status-summary-01.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test-status-summary-01.yaml
@@ -1,0 +1,161 @@
+---
+- name: Create ResourceProvider test-status-summary-01
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceProvider
+      metadata:
+        name: test-status-summary-01
+        namespace: "{{ poolboy_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        override:
+          apiVersion: "{{ poolboy_domain }}/v1"
+          kind: ResourceClaimTest
+          metadata:
+            name: test-status-summary-01-{% raw %}{{ guid }}{% endraw %}
+            namespace: "{{ poolboy_test_namespace }}"
+        parameters:
+        - name: stringvar
+          required: true
+          validation:
+            openAPIV3Schema:
+              type: sting
+              default: one
+              enum:
+              - one
+              - two
+              - three
+        statusSummaryTemplate:
+          stringValue: "{% raw %}{{ resources[0].state.spec.stringvalue }}{% endraw %}"
+        template:
+          definition:
+            spec:
+              stringvalue: "{% raw %}{{ stringvar }}{% endraw %}"
+          enable: true
+        updateFilters:
+        - pathMatch: /spec/.*
+          allowedOps:
+          - replace
+ 
+- name: Create ResourceClaim test-status-summary-01-a
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceClaim
+      metadata:
+        name: test-status-summary-01-a
+        namespace: "{{ poolboy_test_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        provider:
+          name: test-status-summary-01
+          parameterValues:
+            numbervar: 1
+
+- name: Verify handling of ResourceClaim test-status-summary-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-status-summary-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: >-
+    r_get_resource_claim.resources[0].status.resources[0].state is undefined
+  until: r_get_resource_claim is success
+  delay: 1
+  retries: 10
+
+- name: Save facts from for ResourceClaim test-status-summary-01-a
+  vars:
+    __name: >-
+      {{ r_get_resource_claim.resources[0].status.resourceHandle.name }}
+  set_fact:
+    resource_claim_test_status_summary_01_a_resource_handle_name: "{{ __name }}"
+    resource_claim_test_status_summary_01_a_resource_name: test-status-summary-01-{{ __name[5:] }}
+
+- name: Verify state of ResourceClaim test-status-summary-01-a
+  vars:
+    __state: "{{ r_get_resource_claim.resources[0] }}"
+  assert:
+    that:
+    - __state.status.resources[0].state.metadata.name == resource_claim_test_status_summary_01_a_resource_name
+    - __state.status.summary.stringValue == 'one'
+
+- name: Update parameters of ResourceClaim test-status-summary-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-status-summary-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    definition:
+      spec:
+        provider:
+          parameterValues:
+            stringvar: two
+
+- name: Verify update of ResourceClaim test-status-summary-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-status-summary-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: >-
+    r_get_resource_claim.resources[0].status.resources[0].state is undefined or
+    r_get_resource_claim.resources[0].status.summary.stringValue != 'two'
+
+  until: r_get_resource_claim is success
+  delay: 1
+  retries: 10
+
+- name: Delete ResourceClaim test-status-summary-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-status-summary-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    state: absent
+
+- name: Verify delete of ResourceClaim test-status-summary-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-status-summary-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: r_get_resource_claim.resources | length != 0
+  until: r_get_resource_claim is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceHandle for test-status-summary-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: "{{ resource_claim_test_status_summary_01_a_resource_handle_name }}"
+    namespace: "{{ poolboy_namespace }}"
+  register: r_get_resource_handle
+  failed_when: r_get_resource_handle.resources | length != 0
+  until: r_get_resource_handle is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceClaimTest test-status-summary-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_status_summary_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: r_get_resource_claim_test.resources | length != 0
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+...

--- a/test/roles/poolboy_test_simple/tasks/test.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test.yaml
@@ -26,6 +26,9 @@
 - include_tasks:
     file: test-parameters-02.yaml
 
+- include_tasks:
+    file: test-status-summary-01.yaml
+
 # OLD TESTS FOLLOW
 
 - name: Create test ResourceProvider


### PR DESCRIPTION
This feature will allow Babylon to write a simple `current_state` in the ResourceClaim `status.summary.current_state` so that our user interface and other code using the API do not have to implement the logic of collecting the current state from individual managed resources.