### PR TITLE
Add ignore feature

### DIFF
--- a/operator/operator.py
+++ b/operator/operator.py
@@ -53,9 +53,18 @@ async def cleanup(logger: kopf.ObjectLogger, **_):
     await Poolboy.on_cleanup()
 
 
-@kopf.on.create(Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims', id='resource_claim_create')
-@kopf.on.resume(Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims', id='resource_claim_resume')
-@kopf.on.update(Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims', id='resource_claim_update')
+@kopf.on.create(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims',
+    id='resource_claim_create', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
+@kopf.on.resume(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims',
+    id='resource_claim_resume', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
+@kopf.on.update(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims',
+    id='resource_claim_update', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
 async def resource_claim_event(
     annotations: kopf.Annotations,
     labels: kopf.Labels,
@@ -81,7 +90,10 @@ async def resource_claim_event(
     await resource_claim.manage(logger=logger)
 
 
-@kopf.on.delete(Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims')
+@kopf.on.delete(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims',
+    labels={Poolboy.ignore_label: kopf.ABSENT},
+)
 async def resource_claim_delete(
     annotations: kopf.Annotations,
     labels: kopf.Labels,
@@ -111,6 +123,7 @@ async def resource_claim_delete(
 @kopf.daemon(Poolboy.operator_domain, Poolboy.operator_version, 'resourceclaims',
     cancellation_timeout = 1,
     initial_delay = Poolboy.manage_handles_interval,
+    labels = {Poolboy.ignore_label: kopf.ABSENT},
 )
 async def resource_claim_daemon(
     annotations: kopf.Annotations,
@@ -137,15 +150,29 @@ async def resource_claim_daemon(
     )
     try:
         while not stopped:
-            await resource_claim.manage(logger=logger)
+            resource_claim = await resource_claim.refetch()
+            if not resource_claim:
+                logger.info(f"{resource_claim} found deleted in daemon")
+                return
+            if not resource_claim.ignore:
+                await resource_claim.manage(logger=logger)
             await asyncio.sleep(Poolboy.manage_claims_interval)
     except asyncio.CancelledError:
         pass
 
 
-@kopf.on.create(Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles', id='resource_handle_create')
-@kopf.on.resume(Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles', id='resource_handle_resume')
-@kopf.on.update(Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles', id='resource_handle_update')
+@kopf.on.create(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles',
+    id='resource_handle_create', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
+@kopf.on.resume(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles',
+    id='resource_handle_resume', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
+@kopf.on.update(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles',
+    id='resource_handle_update', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
 async def resource_handle_event(
     annotations: kopf.Annotations,
     labels: kopf.Labels,
@@ -171,7 +198,10 @@ async def resource_handle_event(
     await resource_handle.manage(logger=logger)
 
 
-@kopf.on.delete(Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles')
+@kopf.on.delete(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles',
+    labels={Poolboy.ignore_label: kopf.ABSENT},
+)
 async def resource_handle_delete(
     annotations: kopf.Annotations,
     labels: kopf.Labels,
@@ -184,7 +214,7 @@ async def resource_handle_delete(
     uid: str,
     **_
 ):
-    await ResourceHandle.unregister(name, logger=logger)
+    await ResourceHandle.unregister(name)
     resource_handle = ResourceHandle(
         annotations = annotations,
         labels = labels,
@@ -201,6 +231,7 @@ async def resource_handle_delete(
 @kopf.daemon(Poolboy.operator_domain, Poolboy.operator_version, 'resourcehandles',
     cancellation_timeout = 1,
     initial_delay = Poolboy.manage_handles_interval,
+    labels = {Poolboy.ignore_label: kopf.ABSENT},
 )
 async def resource_handle_daemon(
     annotations: kopf.Annotations,
@@ -227,15 +258,29 @@ async def resource_handle_daemon(
     )
     try:
         while not stopped:
-            await resource_handle.manage(logger=logger)
+            resource_handle = await resource_handle.refetch()
+            if not resource_handle:
+                logger.info(f"{resource_handle} found deleted in daemon")
+                return
+            if not resource_handle.ignore:
+                await resource_handle.manage(logger=logger)
             await asyncio.sleep(Poolboy.manage_handles_interval)
     except asyncio.CancelledError:
         pass
 
 
-@kopf.on.create(Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools', id='resource_pool_create')
-@kopf.on.resume(Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools', id='resource_pool_resume')
-@kopf.on.update(Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools', id='resource_pool_update')
+@kopf.on.create(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools',
+    id='resource_pool_create', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
+@kopf.on.resume(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools',
+    id='resource_pool_resume', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
+@kopf.on.update(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools',
+    id='resource_pool_update', labels={Poolboy.ignore_label: kopf.ABSENT},
+)
 async def resource_pool_event(
     annotations: kopf.Annotations,
     labels: kopf.Labels,
@@ -261,7 +306,10 @@ async def resource_pool_event(
     await resource_pool.manage(logger=logger)
 
 
-@kopf.on.delete(Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools')
+@kopf.on.delete(
+    Poolboy.operator_domain, Poolboy.operator_version, 'resourcepools',
+    labels={Poolboy.ignore_label: kopf.ABSENT},
+)
 async def resource_pool_delete(
     annotations: kopf.Annotations,
     labels: kopf.Labels,

--- a/operator/poolboy.py
+++ b/operator/poolboy.py
@@ -8,6 +8,7 @@ class Poolboy():
     operator_version = os.environ.get('OPERATOR_VERSION', 'v1')
     operator_api_version = f"{operator_domain}/{operator_version}"
     resource_refresh_interval = int(os.environ.get('RESOURCE_REFRESH_INTERVAL', 600))
+    ignore_label = f"{operator_domain}/ignore"
 
     @classmethod
     async def on_cleanup(cls):

--- a/test/roles/poolboy_test_simple/tasks/test-ignore-01.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test-ignore-01.yaml
@@ -1,0 +1,500 @@
+---
+- name: Create ResourceProvider test-ignore-01
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceProvider
+      metadata:
+        name: test-ignore-01
+        namespace: "{{ poolboy_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        override:
+          apiVersion: "{{ poolboy_domain }}/v1"
+          kind: ResourceClaimTest
+          metadata:
+            name: test-ignore-01-{% raw %}{{ guid }}{% endraw %}
+            namespace: "{{ poolboy_test_namespace }}"
+        parameters:
+        - name: stringvar
+          allowUpdate: true
+          required: true
+          validation:
+            openAPIV3Schema:
+              type: string
+              default: one
+              enum:
+              - one
+              - two
+              - three
+        template:
+          definition:
+            spec:
+              stringvalue: "{% raw %}{{ stringvar }}{% endraw %}"
+              ts: "{% raw %}{{ now(true, '%FT%TZ') }}{% endraw %}"
+          enable: true
+        updateFilters:
+        - pathMatch: /spec/.*
+          allowedOps:
+          - replace
+
+- name: Create ResourceClaim test-ignore-01-a
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceClaim
+      metadata:
+        name: test-ignore-01-a
+        namespace: "{{ poolboy_test_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        provider:
+          name: test-ignore-01
+          parameterValues:
+            stringvar: "one"
+
+- name: Verify handling of ResourceClaim test-ignore-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: >-
+    r_get_resource_claim.resources[0].status.resources[0].state is undefined
+  until: r_get_resource_claim is success
+  delay: 1
+  retries: 10
+
+- name: Save facts from for ResourceClaim test-ignore-01-a
+  vars:
+    __name: >-
+      {{ r_get_resource_claim.resources[0].status.resourceHandle.name }}
+  set_fact:
+    resource_claim_test_ignore_01_a_resource_handle_name: "{{ __name }}"
+    resource_claim_test_ignore_01_a_resource_name: test-ignore-01-{{ __name[5:] }}
+
+- name: Verify state of ResourceClaim test-ignore-01-a
+  vars:
+    __state: "{{ r_get_resource_claim.resources[0] }}"
+  assert:
+    that:
+    - __state.status.resources[0].state.metadata.name == resource_claim_test_ignore_01_a_resource_name
+    - __state.status.resources[0].state.spec.stringvalue == "one"
+    - __state.status.resources[0].state.spec.ts is match("\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$")
+
+- name: Verify creation of ResourceClaimTest test-ignore-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_ignore_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when:  r_get_resource_claim_test.resources | length != 1
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+
+- name: Set ignore label on ResourceHandle for test-ignore-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: "{{ resource_claim_test_ignore_01_a_resource_handle_name }}"
+    namespace: "{{ poolboy_namespace }}"
+    definition:
+      metadata:
+        labels: >-
+          {{ {poolboy_domain ~ '/ignore': ''} }}
+
+- name: Set ignore label on ResourceClaim test-ignore-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    definition:
+      metadata:
+        labels: >-
+          {{ {poolboy_domain ~ '/ignore': ''} }}
+
+- name: Verify ResourceClaimTest for test-ignore-01-a is no longer managed
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_ignore_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: >-
+    r_get_resource_claim_test.resources | length != 1 or
+    (now(true) - r_get_resource_claim_test.resources[0].spec.ts | to_datetime('%Y-%m-%dT%H:%M:%SZ')).total_seconds() < 10
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 20
+
+- name: Clear ignore label on ResourceHandle for test-ignore-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: "{{ resource_claim_test_ignore_01_a_resource_handle_name }}"
+    namespace: "{{ poolboy_namespace }}"
+    definition:
+      metadata:
+        labels: >-
+          {{ {poolboy_domain ~ '/ignore': None} }}
+
+- name: Clear ignore label on ResourceClaim test-ignore-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    definition:
+      metadata:
+        labels: >-
+          {{ {poolboy_domain ~ '/ignore': None} }}
+
+- name: Verify ResourceClaimTest for test-ignore-01-a is again managed
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_ignore_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: >-
+    r_get_resource_claim_test.resources | length != 1 or
+    (now(true) - r_get_resource_claim_test.resources[0].spec.ts | to_datetime('%Y-%m-%dT%H:%M:%SZ')).total_seconds() > 10
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 20
+
+- name: Delete ResourceClaim test-ignore-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    state: absent
+
+- name: Verify delete of ResourceClaim test-ignore-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: r_get_resource_claim.resources | length != 0
+  until: r_get_resource_claim is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceHandle for test-ignore-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: "{{ resource_claim_test_ignore_01_a_resource_handle_name }}"
+    namespace: "{{ poolboy_namespace }}"
+  register: r_get_resource_handle
+  failed_when: r_get_resource_handle.resources | length != 0
+  until: r_get_resource_handle is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceClaimTest for test-ignore-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_ignore_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: r_get_resource_claim_test.resources | length != 0
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+
+- name: Create ResourceClaim test-ignore-01-b
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceClaim
+      metadata:
+        annotations: 
+          poolboy.dev.local/resource-claim-init-timestamp: "1970-01-01T00:00:00Z"
+        finalizers:
+        - "{{ poolboy_domain }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/ignore": "",
+            poolboy_domain ~ "/test": "simple",
+          } }}
+        name: test-ignore-01-b
+        namespace: "{{ poolboy_test_namespace }}"
+      spec:
+        provider:
+          name: test-ignore-01
+          parameterValues:
+            stringvar: "one"
+
+- name: Verify ResourceClaim test-ignore-01-b has been ignored
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-b
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: >-
+    r_get_resource_claim.resources | length != 1 or
+    r_get_resource_claim.resources[0].status is defined
+
+- name: Restore status on ResourceClaim test-ignore-01-b
+  poolboy_test_merge_patch_status:
+    api_version: "{{ poolboy_domain }}/v1"
+    name: test-ignore-01-b
+    namespace: "{{ poolboy_test_namespace }}"
+    plural: resourceclaims
+    status_patch:
+      diffBase: |
+
+        {
+          "metadata": {
+            "labels": {
+              "{{ poolboy_domain }}/test": "simple"
+            },
+            "annotations": {
+              "poolboy.dev.local/resource-claim-init-timestamp": "1970-01-01T00:00:00Z"
+            }
+          },
+          "spec": {
+            "provider": {
+              "name": "test-ignore-01",
+              "parameterValues": {
+                "stringvar": "one"
+              }
+            }
+          }
+        }
+      lifespan:
+        start: "2023-11-16T03:49:33Z"
+      provider:
+        name: test-ignore-01
+        parameterValues:
+          stringvar: one
+      resourceHandle:
+        apiVersion: poolboy.dev.local/v1
+        kind: ResourceHandle
+        name: guid-abcde
+        namespace: poolboy-dev
+      resources:
+      - name: test-ignore-01
+        provider:
+          apiVersion: poolboy.dev.local/v1
+          kind: ResourceProvider
+          name: test-ignore-01
+          namespace: poolboy-dev
+
+- name: Create ResourceHandle guid-abcde
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceHandle
+      metadata:
+        finalizers:
+        - "{{ poolboy_domain }}"
+        generateName: guid-
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/ignore": "",
+            poolboy_domain ~ "/resource-claim-name": "test-ignore-01-b",
+            poolboy_domain ~ "/resource-claim-namespace": poolboy_test_namespace,
+          } }}
+        name: guid-abcde
+        namespace: "{{ poolboy_namespace }}"
+      spec:
+        resourceClaim:
+          apiVersion: "{{ poolboy_domain }}/v1"
+          kind: ResourceClaim
+          name: test-ignore-01-b
+          namespace: "{{ poolboy_test_namespace }}"
+        resources:
+        - name: test-ignore-01
+          provider:
+            apiVersion: "{{ poolboy_domain }}/v1"
+            kind: ResourceProvider
+            name: test-ignore-01
+            namespace: "{{ poolboy_namespace }}"
+          reference:
+            apiVersion: "{{ poolboy_domain }}/v1"
+            kind: ResourceClaimTest
+            name: test-ignore-01-abcde
+            namespace: "{{ poolboy_test_namespace }}"
+          template:
+            spec:
+              stringvalue: one
+              ts: "1970-01-01T00:00:00Z"
+        vars: {}
+
+- name: Verify ResourceHandle guid-abcde has been ignored
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: guid-abcde
+    namespace: "{{ poolboy_namespace }}"
+  register: r_get_resource_handle
+  failed_when: >-
+    r_get_resource_handle.resources | length != 1 or
+    r_get_resource_handle.resources[0].status is defined
+
+- name: Restore status on ResourceHandle guid-abcde
+  poolboy_test_merge_patch_status:
+    api_version: "{{ poolboy_domain }}/v1"
+    name: guid-abcde
+    namespace: "{{ poolboy_namespace }}"
+    plural: resourcehandles
+    status_patch:
+      diffBase: |
+
+        {
+          "metadata": {
+            "labels": {
+              "{{ poolboy_domain }}/resource-claim-name": "test-ignore-01-b",
+              "{{ poolboy_domain }}/resource-claim-namespace": "{{ poolboy_test_namespace }}"
+            }
+          },
+          "spec": {
+            "resourceClaim": {
+              "apiVersion": "{{ poolboy_domain }}/v1",
+              "kind": "ResourceClaim",
+              "name": "test-ignore-01-b",
+              "namespace": "{{ poolboy_test_namespace }}"
+            },
+            "resources": [{
+              "name": "test-ignore-01",
+              "provider": {
+                "apiVersion": "{{ poolboy_domain }}/v1",
+                "kind": "ResourceProvider",
+                "name": "test-ignore-01",
+                "namespace": "{{ poolboy_namespace }}"
+              },
+              "reference": {
+                "apiVersion": "{{ poolboy_domain }}/v1",
+                "kind": "ResourceClaimTest",
+                "name":" test-ignore-01-abcde",
+                "namespace": "{{ poolboy_test_namespace }}"
+              },
+              "template": {
+                "spec": {
+                  "stringvalue": "one",
+                  "ts":"1970-01-01T00:00:00Z"
+                }
+              }
+            }],
+            "vars":{}
+          }
+        }
+
+- name: Create ResourceHandle guid-abcde
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: poolboy.dev.local/v1
+      kind: ResourceClaimTest
+      metadata:
+        annotations:
+          poolboy.dev.local/resource-claim-name: test-ignore-01-b
+          poolboy.dev.local/resource-claim-namespace: "{{ poolboy_test_namespace }}"
+          poolboy.dev.local/resource-handle-name: guid-abcde
+          poolboy.dev.local/resource-handle-namespace: "{{ poolboy_namespace }}"
+          poolboy.dev.local/resource-handle-uid: 00000000-0000-0000-0000-000000000000
+          poolboy.dev.local/resource-index: "0"
+          poolboy.dev.local/resource-provider-name: test-ignore-01
+          poolboy.dev.local/resource-provider-namespace: "{{ poolboy_namespace }}"
+        name: test-ignore-01-abcde
+        namespace: "{{ poolboy_test_namespace }}"
+      spec:
+        stringvalue: one
+        ts: "1970-01-01T00:00:00Z"
+  
+- name: Clear ignore label on ResourceHandle for test-ignore-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: guid-abcde
+    namespace: "{{ poolboy_namespace }}"
+    definition:
+      metadata:
+        labels: >-
+          {{ {poolboy_domain ~ '/ignore': None} }}
+
+- name: Clear ignore label on ResourceClaim test-ignore-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-b
+    namespace: "{{ poolboy_test_namespace }}"
+    definition:
+      metadata:
+        labels: >-
+          {{ {poolboy_domain ~ '/ignore': None} }}
+
+- name: Verify ResourceClaimTest for test-ignore-01-b is managed
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: test-ignore-01-abcde
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: >-
+    r_get_resource_claim_test.resources | length != 1 or
+    (now(true) - r_get_resource_claim_test.resources[0].spec.ts | to_datetime('%Y-%m-%dT%H:%M:%SZ')).total_seconds() > 10
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 20
+
+- name: Delete ResourceClaim test-ignore-01-b
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-b
+    namespace: "{{ poolboy_test_namespace }}"
+    state: absent
+
+- name: Verify delete of ResourceClaim test-ignore-01-b
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-ignore-01-b
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: r_get_resource_claim.resources | length != 0
+  until: r_get_resource_claim is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceHandle for test-ignore-01-b
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: test-ignore-01-abcde
+    namespace: "{{ poolboy_namespace }}"
+  register: r_get_resource_handle
+  failed_when: r_get_resource_handle.resources | length != 0
+  until: r_get_resource_handle is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceClaimTest for test-ignore-01-b
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: test-ignore-01-abcde
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: r_get_resource_claim_test.resources | length != 0
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+...

--- a/test/roles/poolboy_test_simple/tasks/test.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test.yaml
@@ -6,6 +6,7 @@
   - test-01.yaml
   - test-02.yaml
   - test-approval-01.yaml
+  - test-ignore-01.yaml
   - test-linked-01.yaml
   - test-linked-02.yaml
   - test-pool-01.yaml


### PR DESCRIPTION
Ignore feature allows resources to be labeled with `poolboy.gpte.redhat.com/ignore` to prevent handling until restore is complete or to prevent normal delete handling of managed resources.