### PR TITLE
Add auto-delete and auto-detach feature for ResourceClaims

### DIFF
--- a/helm/crds/resourceclaims.yaml
+++ b/helm/crds/resourceclaims.yaml
@@ -50,6 +50,26 @@ spec:
             description: ResourceClaim specification
             type: object
             properties:
+              autoDelete:
+                description: |
+                  Configuration for auto-delete of the ResourceClaim.
+                type: object
+                properties:
+                  when:
+                    description: |
+                      Condition to check which triggers deletion.
+                      Condition is given in Jinja2 syntax similar to ansible "when" clauses.
+                    type: string
+              autoDetach:
+                description: |
+                  Configuration for auto-delete of the ResourceClaim.
+                type: object
+                properties:
+                  when:
+                    description: |
+                      Condition to check which triggers detach of ResourceHandle from the ResourceClaim.
+                      Condition is given in Jinja2 syntax similar to ansible "when" clauses.
+                    type: string
               lifespan:
                 description: >-
                   Lifespan configuration for the ResourceClaim.
@@ -203,6 +223,10 @@ spec:
                 properties:
                   apiVersion:
                     type: string
+                  detached:
+                    description: >-
+                      If true then ResourceHandle is no longer associated to this ResourceClaim.
+                    type: boolean
                   kind:
                     type: string
                   name:

--- a/helm/templates/crds/resourceclaims.yaml
+++ b/helm/templates/crds/resourceclaims.yaml
@@ -51,6 +51,26 @@ spec:
             description: ResourceClaim specification
             type: object
             properties:
+              autoDelete:
+                description: |
+                  Configuration for auto-delete of the ResourceClaim.
+                type: object
+                properties:
+                  when:
+                    description: |
+                      Condition to check which triggers deletion.
+                      Condition is given in Jinja2 syntax similar to ansible "when" clauses.
+                    type: string
+              autoDetach:
+                description: |
+                  Configuration for auto-delete of the ResourceClaim.
+                type: object
+                properties:
+                  when:
+                    description: |
+                      Condition to check which triggers detach of ResourceHandle from the ResourceClaim.
+                      Condition is given in Jinja2 syntax similar to ansible "when" clauses.
+                    type: string
               lifespan:
                 description: >-
                   Lifespan configuration for the ResourceClaim.
@@ -204,6 +224,10 @@ spec:
                 properties:
                   apiVersion:
                     type: string
+                  detached:
+                    description: >-
+                      If true then ResourceHandle is no longer associated to this ResourceClaim.
+                    type: boolean
                   kind:
                     type: string
                   name:

--- a/operator/resourcewatcher.py
+++ b/operator/resourcewatcher.py
@@ -197,6 +197,11 @@ class ResourceWatcher:
                         name = resource_claim_name,
                         namespace = resource_claim_namespace,
                     )
+
+                    # Do not manage status for detached ResourceClaim
+                    if resource_claim.is_detached:
+                        continue
+
                     prev_state = resource_claim.status_resources[resource_index].get('state')
                     prev_description = (
                         f"{prev_state['apiVersion']} {prev_state['kind']} {resource_name} in {resource_namespace}"

--- a/test/roles/poolboy_test_simple/tasks/test-auto-delete-01.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test-auto-delete-01.yaml
@@ -1,0 +1,153 @@
+---
+- name: Create ResourceProvider test-auto-delete-01
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceProvider
+      metadata:
+        name: test-auto-delete-01
+        namespace: "{{ poolboy_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        override:
+          apiVersion: "{{ poolboy_domain }}/v1"
+          kind: ResourceClaimTest
+          metadata:
+            name: test-auto-delete-01-{% raw %}{{ guid }}{% endraw %}
+            namespace: "{{ poolboy_test_namespace }}"
+        parameters:
+        - name: stringvar
+          allowUpdate: true
+          required: true
+        statusSummaryTemplate:
+          stringValue: "{% raw %}{{ resources[0].state.spec.stringvalue }}{% endraw %}"
+        template:
+          definition:
+            spec:
+              stringvalue: "{% raw %}{{ stringvar }}{% endraw %}"
+          enable: true
+        updateFilters:
+        - pathMatch: /spec/.*
+          allowedOps:
+          - replace
+ 
+- name: Create ResourceClaim test-auto-delete-01-a
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceClaim
+      metadata:
+        name: test-auto-delete-01-a
+        namespace: "{{ poolboy_test_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        autoDelete:
+          when: status.summary.stringValue|default('') == 'delete'
+        provider:
+          name: test-auto-delete-01
+          parameterValues:
+            stringvar: foo
+
+- name: Verify handling of ResourceClaim test-auto-delete-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-auto-delete-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: >-
+    r_get_resource_claim.resources[0].status.resources[0].state is undefined
+  until: r_get_resource_claim is success
+  delay: 2
+  retries: 10
+
+- name: Save facts from for ResourceClaim test-auto-delete-01-a
+  vars:
+    __name: >-
+      {{ r_get_resource_claim.resources[0].status.resourceHandle.name }}
+  set_fact:
+    resource_claim_test_auto_delete_01_a_resource_handle_name: "{{ __name }}"
+    resource_claim_test_auto_delete_01_a_resource_name: test-auto-delete-01-{{ __name[5:] }}
+
+- name: Verify state of ResourceClaim test-auto-delete-01-a
+  vars:
+    __state: "{{ r_get_resource_claim.resources[0] }}"
+  assert:
+    that:
+    - __state.status.resources[0].state.metadata.name == resource_claim_test_auto_delete_01_a_resource_name
+
+- name: Verify creation of ResourceClaimTest test-auto-delete-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_auto_delete_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when:  r_get_resource_claim_test.resources | length != 1
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+
+- name: Verify state of ResourceClaimTest for test-auto-delete-01-a
+  vars:
+    __state: "{{ r_get_resource_claim_test.resources[0] }}"
+  assert:
+    that:
+    - __state.spec.stringvalue == 'foo'
+
+- name: Update parameters of ResourceClaim test-auto-delete-01-a to trigger delete
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-auto-delete-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    definition:
+      spec:
+        provider:
+          parameterValues:
+            stringvar: delete
+
+- name: Verify delete of ResourceClaim test-auto-delete-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-auto-delete-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: r_get_resource_claim.resources | length != 0
+  until: r_get_resource_claim is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceHandle for test-auto-delete-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: "{{ resource_claim_test_auto_delete_01_a_resource_handle_name }}"
+    namespace: "{{ poolboy_namespace }}"
+  register: r_get_resource_handle
+  failed_when: r_get_resource_handle.resources | length != 0
+  until: r_get_resource_handle is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceClaimTest test-auto-delete-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_auto_delete_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: r_get_resource_claim_test.resources | length != 0
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+
+- fail:
+...

--- a/test/roles/poolboy_test_simple/tasks/test-auto-detach-01.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test-auto-detach-01.yaml
@@ -1,0 +1,173 @@
+---
+- name: Create ResourceProvider test-auto-detach-01
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceProvider
+      metadata:
+        name: test-auto-detach-01
+        namespace: "{{ poolboy_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        override:
+          apiVersion: "{{ poolboy_domain }}/v1"
+          kind: ResourceClaimTest
+          metadata:
+            name: test-auto-detach-01-{% raw %}{{ guid }}{% endraw %}
+            namespace: "{{ poolboy_test_namespace }}"
+        parameters:
+        - name: stringvar
+          allowUpdate: true
+          required: true
+        statusSummaryTemplate:
+          stringValue: "{% raw %}{{ resources[0].state.spec.stringvalue }}{% endraw %}"
+        template:
+          definition:
+            spec:
+              stringvalue: "{% raw %}{{ stringvar }}{% endraw %}"
+          enable: true
+        updateFilters:
+        - pathMatch: /spec/.*
+          allowedOps:
+          - replace
+ 
+- name: Create ResourceClaim test-auto-detach-01-a
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: "{{ poolboy_domain }}/v1"
+      kind: ResourceClaim
+      metadata:
+        name: test-auto-detach-01-a
+        namespace: "{{ poolboy_test_namespace }}"
+        labels: >-
+          {{ {
+            poolboy_domain ~ "/test": "simple"
+          } }}
+      spec:
+        autoDetach:
+          when: status.summary.stringValue|default('') == 'detach'
+        provider:
+          name: test-auto-detach-01
+          parameterValues:
+            stringvar: foo
+
+- name: Verify handling of ResourceClaim test-auto-detach-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-auto-detach-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: >-
+    r_get_resource_claim.resources[0].status.resources[0].state is undefined
+  until: r_get_resource_claim is success
+  delay: 2
+  retries: 10
+
+- name: Save facts from for ResourceClaim test-auto-detach-01-a
+  vars:
+    __name: >-
+      {{ r_get_resource_claim.resources[0].status.resourceHandle.name }}
+  set_fact:
+    resource_claim_test_auto_detach_01_a_resource_handle_name: "{{ __name }}"
+    resource_claim_test_auto_detach_01_a_resource_name: test-auto-detach-01-{{ __name[5:] }}
+
+- name: Verify state of ResourceClaim test-auto-detach-01-a
+  vars:
+    __state: "{{ r_get_resource_claim.resources[0] }}"
+  assert:
+    that:
+    - __state.status.resources[0].state.metadata.name == resource_claim_test_auto_detach_01_a_resource_name
+
+- name: Verify creation of ResourceClaimTest test-auto-detach-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_auto_detach_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when:  r_get_resource_claim_test.resources | length != 1
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+
+- name: Verify state of ResourceClaimTest for test-auto-detach-01-a
+  vars:
+    __state: "{{ r_get_resource_claim_test.resources[0] }}"
+  assert:
+    that:
+    - __state.spec.stringvalue == 'foo'
+
+- name: Update parameters of ResourceClaim test-auto-detach-01-a to trigger detach
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-auto-detach-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    definition:
+      spec:
+        provider:
+          parameterValues:
+            stringvar: detach
+
+- name: Verify detach of ResourceClaim test-auto-detach-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-auto-detach-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: |
+    r_get_resource_claim.resources | length != 1 or
+    not r_get_resource_claim.resources[0].status.resourceHandle.detached | default(False) | bool
+  until: r_get_resource_claim is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceHandle for test-auto-detach-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceHandle
+    name: "{{ resource_claim_test_auto_detach_01_a_resource_handle_name }}"
+    namespace: "{{ poolboy_namespace }}"
+  register: r_get_resource_handle
+  failed_when: r_get_resource_handle.resources | length != 0
+  until: r_get_resource_handle is success
+  retries: 5
+  delay: 1
+
+- name: Verify delete of ResourceClaimTest test-auto-detach-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaimTest
+    name: "{{ resource_claim_test_auto_detach_01_a_resource_name }}"
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim_test
+  failed_when: r_get_resource_claim_test.resources | length != 0
+  until: r_get_resource_claim_test is success
+  delay: 1
+  retries: 10
+
+- name: Delete ResourceClaim test-auto-detach-01-a
+  kubernetes.core.k8s:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-auto-detach-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+    state: absent
+
+- name: Verify delete of ResourceClaim test-parameters-01-a
+  kubernetes.core.k8s_info:
+    api_version: "{{ poolboy_domain }}/v1"
+    kind: ResourceClaim
+    name: test-parameters-01-a
+    namespace: "{{ poolboy_test_namespace }}"
+  register: r_get_resource_claim
+  failed_when: r_get_resource_claim.resources | length != 0
+  until: r_get_resource_claim is success
+  retries: 5
+  delay: 1
+...

--- a/test/roles/poolboy_test_simple/tasks/test.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test.yaml
@@ -20,6 +20,8 @@
   - test-parameters-04.yaml
   - test-parameters-05.yaml
   - test-status-summary-01.yaml
+  - test-auto-delete-01.yaml
+  - test-auto-detach-01.yaml
 
 # OLD TESTS FOLLOW
 


### PR DESCRIPTION
- Auto-delete allows the ResourceClaim to automatically delete based on the resource status.
- Auto-detach allows the ResoruceClaim to delete its ResourceHandle and transition to a "detached" state.