### PR TITLE
Fix resource watcher issue on early disconnect.

### DIFF
--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -391,7 +391,8 @@ class ResourceHandle:
             definition = await Poolboy.custom_objects_api.get_namespaced_custom_object(
                 Poolboy.operator_domain, Poolboy.operator_version, Poolboy.namespace, 'resourcehandles', name
             )
-
+            if 'deletionTimestamp' in definition['metadata']:
+                return None
             return ResourceHandle.__register_definition(definition=definition)
 
     @staticmethod


### PR DESCRIPTION
In some situations the resource watch can disconnect before all resources are seen. This fix implements a full list of all watched resources before the actual watch begins.