### PR TITLE
Remove 'prometheus' field from metrics port

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -75,7 +75,6 @@ service:
   ports:
   - name: metrics
     port: 9091
-    prometheus: 9091
     protocol: TCP
     targetPort: 9091
 


### PR DESCRIPTION
Removed the 'prometheus' field from the metrics port configuration.