### PR TITLE
Fixes following incident with v1.17.0

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -5,6 +5,6 @@ set -eo pipefail
 shopt -s dotglob
 
 # Install customized kopf version with label selectors and deprecated finalizer support.
-pip install git+https://github.com/rhpds/kopf.git@add-deprecated-finalizer-support
+pip install git+https://github.com/rhpds/kopf.git@add-label-selector
 
 /usr/libexec/s2i/assemble

--- a/operator/kopfobject.py
+++ b/operator/kopfobject.py
@@ -89,10 +89,6 @@ class KopfObject(metaclass=TimerDecoratorMeta):
         return f"{self.kind} {self.name} in {self.namespace}"
 
     @property
-    def api_group_version(self):
-        return f"{self.api_group}/{self.api_version}"
-
-    @property
     def creation_datetime(self):
         return datetime.strptime(self.creation_timestamp, "%Y-%m-%dT%H:%H:%S%z")
 

--- a/operator/operator.py
+++ b/operator/operator.py
@@ -36,10 +36,6 @@ async def startup(logger: kopf.ObjectLogger, settings: kopf.OperatorSettings, **
         Poolboy.operator_domain
     )
 
-    # Support deprecated resource handler finalizer
-    if Poolboy.operator_mode_resource_handler or Poolboy.operator_mode_all_in_one:
-        settings.persistence.deprecated_finalizer = re.compile(re.escape(Poolboy.operator_domain) + '/handler-[0-9]+$')
-
     # Store progress in status.
     settings.persistence.progress_storage = kopf.StatusProgressStorage(field='status.kopf.progress')
 

--- a/operator/operator.py
+++ b/operator/operator.py
@@ -5,6 +5,8 @@ import re
 from typing import Mapping
 
 import kopf
+from kubernetes_asyncio.client import ApiException as K8sApiException
+
 from configure_kopf_logging import configure_kopf_logging
 from infinite_relative_backoff import InfiniteRelativeBackoff
 from metrics import MetricsService
@@ -277,10 +279,12 @@ if Poolboy.operator_mode_resource_handler or Poolboy.operator_mode_all_in_one:
         )
         try:
             while not stopped:
-                description = str(resource_claim)
-                resource_claim = await resource_claim.refetch()
-                if not resource_claim:
-                    logger.info(f"{description} found deleted in daemon")
+                try:
+                    await resource_claim.refetch()
+                except K8sApiException as exception:
+                    if exception.status != 404:
+                        raise
+                    logger.info(f"{resource_claim} found deleted in daemon")
                     return
                 if not resource_claim.ignore:
                     await resource_claim.manage(logger=logger)
@@ -391,9 +395,11 @@ if Poolboy.operator_mode_resource_handler or Poolboy.operator_mode_all_in_one:
         )
         try:
             while not stopped:
-                description = str(resource_handle)
-                resource_handle = await resource_handle.refetch()
-                if not resource_handle:
+                try:
+                    await resource_handle.refetch()
+                except K8sApiException as exception:
+                    if exception.status != 404:
+                        raise
                     logger.info(f"{description} found deleted in daemon")
                     return
                 if not resource_handle.ignore:

--- a/operator/resourceclaim.py
+++ b/operator/resourceclaim.py
@@ -50,6 +50,7 @@ def prune_k8s_resource(resource: Mapping) -> Mapping:
 class ResourceClaim(KopfObject):
     api_group = Poolboy.operator_domain
     api_version = Poolboy.operator_version
+    api_group_version = f"{api_group}/{api_version}"
     kind = "ResourceClaim"
     plural = "resourceclaims"
 
@@ -1005,19 +1006,6 @@ class ResourceClaim(KopfObject):
 
         if patch:
             await resource_handle.json_patch(patch)
-
-    async def refetch(self) -> ResourceClaimT|None:
-        try:
-            definition = await Poolboy.custom_objects_api.get_namespaced_custom_object(
-                Poolboy.operator_domain, Poolboy.operator_version, self.namespace, 'resourceclaims', self.name
-            )
-            self.refresh_from_definition(definition)
-            return self
-        except kubernetes_asyncio.client.exceptions.ApiException as e:
-            if e.status == 404:
-                await self.unregister(name=self.name, namespace=self.namespace)
-                return None
-            raise
 
     async def validate(self,
         logger: kopf.ObjectLogger,

--- a/operator/resourceclaim.py
+++ b/operator/resourceclaim.py
@@ -665,23 +665,27 @@ class ResourceClaim(KopfObject):
                 else:
                     raise
 
-    async def handle_delete(self, logger: kopf.ObjectLogger):
-        if self.has_resource_handle:
-            try:
-                await Poolboy.custom_objects_api.delete_namespaced_custom_object(
-                    group = Poolboy.operator_domain,
-                    name = self.resource_handle_name,
-                    namespace = self.resource_handle_namespace,
-                    plural = 'resourcehandles',
-                    version = Poolboy.operator_version,
-                )
-                logger.info(
-                    f"Propagated delete of ResourceClaim {self.name} in {self.namespace} "
-                    f"to ResourceHandle {self.resource_handle_name}"
-                )
-            except kubernetes_asyncio.client.exceptions.ApiException as exception:
-                if exception.status != 404:
-                    raise
+    async def handle_delete(self, logger: kopf.ObjectLogger) -> None:
+        """Handle delete of ResourceClaim my propagating to delete of any bound
+        ResourceHandle."""
+        if not self.has_resource_handle:
+            logger.info("%s deleted before binding to any ResourceHandle", self)
+            return
+        try:
+            await Poolboy.custom_objects_api.delete_namespaced_custom_object(
+                group = Poolboy.operator_domain,
+                name = self.resource_handle_name,
+                namespace = self.resource_handle_namespace,
+                plural = 'resourcehandles',
+                version = Poolboy.operator_version,
+            )
+            logger.info(
+                "Propagated delete of %s to ResourceHandle %s",
+                self, self.resource_handle_name
+            )
+        except kubernetes_asyncio.client.exceptions.ApiException as exception:
+            if exception.status != 404:
+                raise
 
     async def assign_resource_providers(self, logger) -> None:
         """Assign resource providers in status for ResourceClaim with resources listed in spec."""

--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -3,6 +3,7 @@ import logging
 
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
+from time import time
 from typing import Any, List, Mapping, TypeVar
 from uuid import UUID
 
@@ -572,7 +573,6 @@ class ResourceHandle(KopfObject):
         return cls.all_instances.get(name)
 
     @classmethod
-    # FIXME - Investigate if this is not working
     def start_watch_other(cls) -> None:
         logger = logging.getLogger('watch_other_handles')
         cls.watch_other_task = asyncio.create_task(cls.watch_other(logger))
@@ -690,9 +690,18 @@ class ResourceHandle(KopfObject):
 
     @classmethod
     async def watch_other(cls, logger) -> None:
+        last_start = time()
         while True:
+            logger.info("Starting watch for ResourceHandles managed by other handlers.")
             try:
-                # FIXME - clear stale cache entries
+                # Clear stale cache entries
+                for resource_handle in cls.all_instances.values():
+                    if (
+                        resource_handle.resource_handler_idx != Poolboy.resource_handler_idx and
+                        resource_handle.last_seen < last_start
+                    ):
+                        resource_handle.__unregister()
+                last_start = time()
                 await cls.__watch_other(logger)
             except K8sApiException as exception:
                 if exception.status != 410:
@@ -719,6 +728,10 @@ class ResourceHandle(KopfObject):
                 await cls.unregister(event_obj['metadata']['name'])
             else:
                 await cls.register_definition(event_obj)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.last_seen = time()
 
     def __str__(self) -> str:
         return f"ResourceHandle {self.name}"
@@ -1114,6 +1127,14 @@ class ResourceHandle(KopfObject):
         and (not maximum_end or relative_maximum_end < maximum_end):
             return relative_maximum_end
         return maximum_end
+
+    def refresh(self, **kwargs) -> None:
+        super().refresh(**kwargs)
+        self.last_seen = time()
+
+    def refresh_from_definition(self, definition) -> None:
+        super().refresh_from_definition(definition)
+        self.last_seen = time()
 
     def set_resource_healthy(self, resource_index: int, value: bool|None) -> None:
         if value is None:

--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -840,9 +840,9 @@ class ResourceHandle(KopfObject):
     @property
     def resource_claim_description(self) -> str|None:
         """ResourceClaim descriptive string if bound to ResourceClaim"""
-        if not 'resourceClaim' not in self.spec:
-            return None
-        return f"ResourceClaim {self.resource_claim_name} in {self.resource_claim_namespace}"
+        if 'resourceClaim' in self.spec:
+            return f"ResourceClaim {self.resource_claim_name} in {self.resource_claim_namespace}"
+        return None
 
     @property
     def resource_claim_name(self) -> str|None:

--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -12,6 +12,8 @@ import kopf
 import kubernetes_asyncio
 import pytimeparse
 
+from kubernetes_asyncio.client import ApiException as K8sApiException
+
 import poolboy_k8s
 import resourceclaim
 import resourcepool
@@ -69,6 +71,7 @@ class ResourceHandleMatch:
 class ResourceHandle(KopfObject):
     api_group = Poolboy.operator_domain
     api_version = Poolboy.operator_version
+    api_group_version = f"{api_group}/{api_version}"
     kind = "ResourceHandle"
     plural = "resourcehandles"
 
@@ -109,9 +112,13 @@ class ResourceHandle(KopfObject):
             # Check if there is already an assigned claim
             resource_handle = cls.bound_instances.get((resource_claim.namespace, resource_claim.name))
             if resource_handle:
-                if await resource_handle.refetch():
+                try:
+                    await resource_handle.refetch()
                     logger.warning(f"Rebinding {resource_handle} to {resource_claim}")
                     return resource_handle
+                except K8sApiException as exception:
+                    if exception.status != 404:
+                        raise
                 logger.warning(f"Deleted {resource_handle} was still in memory cache")
 
             claim_status_resources = resource_claim.status_resources
@@ -177,7 +184,12 @@ class ResourceHandle(KopfObject):
             matched_resource_handle = None
             for match in matches:
                 matched_resource_handle = match.resource_handle
-                patch = []
+                # Start by ensuring handle as not already assigned by other handler
+                patch = [{
+                    "op": "test",
+                    "path": "/spec/resourceClaim",
+                    "value": None,
+                }]
                 if 'labels' not in matched_resource_handle.metadata:
                     patch.append({
                         "op": "add",
@@ -260,10 +272,13 @@ class ResourceHandle(KopfObject):
                 try:
                     await matched_resource_handle.json_patch(patch)
                     matched_resource_handle.__register()
-                except kubernetes_asyncio.client.exceptions.ApiException as exception:
+                except K8sApiException as exception:
                     if exception.status == 404:
                         logger.warning(f"Attempt to bind deleted {matched_resource_handle} to {resource_claim}")
                         matched_resource_handle.__unregister()
+                        matched_resource_handle = None
+                    if exception.status == 422:
+                        logger.warning(f"Attempt to bind {matched_resource_handle} to {resource_claim} failed, most likely handle already bound")
                         matched_resource_handle = None
                     else:
                         raise
@@ -557,6 +572,7 @@ class ResourceHandle(KopfObject):
         return cls.all_instances.get(name)
 
     @classmethod
+    # FIXME - Investigate if this is not working
     def start_watch_other(cls) -> None:
         logger = logging.getLogger('watch_other_handles')
         cls.watch_other_task = asyncio.create_task(cls.watch_other(logger))
@@ -678,7 +694,7 @@ class ResourceHandle(KopfObject):
             try:
                 # FIXME - clear stale cache entries
                 await cls.__watch_other(logger)
-            except kubernetes_asyncio.client.exceptions.ApiException as exception:
+            except K8sApiException as exception:
                 if exception.status != 410:
                     logger.exception("Error watching other resourcehandles")
                     await asyncio.sleep(10)
@@ -983,7 +999,7 @@ class ResourceHandle(KopfObject):
                     return
                 await self.json_patch_status(patch)
                 return
-            except kubernetes_asyncio.client.exceptions.ApiException as exception:
+            except K8sApiException as exception:
                 if attempt > 2:
                     logger.exception(f"{self} failed status patch: {patch}")
                     raise
@@ -1142,7 +1158,7 @@ class ResourceHandle(KopfObject):
                     }
                 })
                 await self.json_patch(patch)
-            except kubernetes_asyncio.client.exceptions.ApiException as exception:
+            except K8sApiException as exception:
                 pass
 
     async def get_resource_claim(self, not_found_okay: bool) -> ResourceClaimT|None:
@@ -1154,7 +1170,7 @@ class ResourceHandle(KopfObject):
                 namespace = self.resource_claim_namespace,
                 use_cache = Poolboy.operator_mode_all_in_one,
             )
-        except kubernetes_asyncio.client.exceptions.ApiException as e:
+        except K8sApiException as e:
             if e.status == 404 and not_found_okay:
                 return None
             raise
@@ -1229,7 +1245,7 @@ class ResourceHandle(KopfObject):
                         name = reference['name'],
                         namespace = reference.get('namespace'),
                     )
-                except kubernetes_asyncio.client.exceptions.ApiException as e:
+                except K8sApiException as e:
                     if e.status != 404:
                         raise
 
@@ -1428,7 +1444,7 @@ class ResourceHandle(KopfObject):
             if patch:
                 try:
                     await self.json_patch_status(patch)
-                except kubernetes_asyncio.client.exceptions.ApiException as exception:
+                except K8sApiException as exception:
                     if exception.status == 422:
                         logger.error(f"Failed to apply {patch}")
                     raise
@@ -1446,7 +1462,7 @@ class ResourceHandle(KopfObject):
                     if created_resource:
                         resource_states[resource_index] = created_resource
                         logger.info(f"Created {resource_description} for {self}")
-                except kubernetes_asyncio.client.exceptions.ApiException as exception:
+                except K8sApiException as exception:
                     if exception.status != 409:
                         raise
 
@@ -1456,19 +1472,6 @@ class ResourceHandle(KopfObject):
                     resource_handle=self,
                     resource_states=resource_states,
                 )
-
-    async def refetch(self) -> ResourceHandleT|None:
-        try:
-            definition = await Poolboy.custom_objects_api.get_namespaced_custom_object(
-                Poolboy.operator_domain, Poolboy.operator_version, Poolboy.namespace, 'resourcehandles', self.name
-            )
-            self.refresh_from_definition(definition)
-            return self
-        except kubernetes_asyncio.client.exceptions.ApiException as e:
-            if e.status == 404:
-                await self.unregister(name=self.name)
-                return None
-            raise
 
     async def update_status(self,
         logger: kopf.ObjectLogger,
@@ -1481,7 +1484,14 @@ class ResourceHandle(KopfObject):
         while len(self.resources) < len(resource_states):
             logger.warning(f"{self} update status with resource states longer that list of resources, attempting refetch: {len(self.resources)} < {len(resource_states)}")
             await asyncio.sleep(0.2)
-            await self.refetch()
+            try:
+                await self.refetch()
+            except K8sApiException as exception:
+                if exception.status == 404:
+                    logger.info("Ignoring update status on deleted %s", self)
+                    return
+                raise
+
             if len(self.resources) < len(resource_states):
                 logger.error(f"{self} update status with resource states longer that list of resources after refetch: {len(self.resources)} < {len(resource_states)}")
                 return
@@ -1607,18 +1617,20 @@ class ResourceHandle(KopfObject):
                         "path": "/status/summary",
                         "value": status_summary,
                     })
-        except kubernetes_asyncio.client.exceptions.ApiException:
+        except K8sApiException:
             logger.exception(
                 f"Failed to get ResourceProvider {resource_provider_name} for {self}"
             )
         except Exception:
             logger.exception(f"Failed to generate status summary for {self}")
+
         if patch:
+            patch_attempt = 0
             while True:
                 try:
                     await self.json_patch_status(patch)
                     break
-                except kubernetes_asyncio.client.exceptions.ApiException:
+                except K8sApiException:
                     patch_attempt += 1
                     if patch_attempt > 5:
                         logger.exception(f"Failed to patch status on {self}")

--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -1032,7 +1032,7 @@ class ResourceHandle(KopfObject):
             await self.delete()
             return True
         if self.is_bound and not resource_claim:
-            logger.info(f"Propagating deletion of {self.resource_claim_description} to {self}")
+            logger.warning(f"Propagating deletion of {self.resource_claim_description} to {self}")
             await self.delete()
             return True
 

--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -38,7 +38,7 @@ class ResourceHandleMatch:
     def __lt__(self, cmp):
         '''Compare matches by preference'''
         if self.resource_count_difference != cmp.resource_count_difference:
-            self.resource_count_difference < cmp.resource_count_difference
+            return self.resource_count_difference < cmp.resource_count_difference
 
         if self.resource_name_difference_count != cmp.resource_name_difference_count:
             return self.resource_name_difference_count < cmp.resource_name_difference_count

--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -763,7 +763,7 @@ class ResourceHandle(KopfObject):
 
     @property
     def has_lifespan_end(self) -> bool:
-        'end' in self.spec.get('lifespan', {})
+        return 'end' in self.spec.get('lifespan', {})
 
     @property
     def has_resource_provider(self) -> bool:

--- a/operator/resourcepool.py
+++ b/operator/resourcepool.py
@@ -23,6 +23,7 @@ ResourceProviderT = TypeVar('ResourceProviderT', bound='ResourceProvider')
 class ResourcePool(KopfObject):
     api_group = Poolboy.operator_domain
     api_version = Poolboy.operator_version
+    api_group_version = f"{api_group}/{api_version}"
     kind = "ResourcePool"
     plural = "resourcepools"
 

--- a/operator/resourcepoolscaling.py
+++ b/operator/resourcepoolscaling.py
@@ -101,6 +101,8 @@ class ResourcePoolScaling(KopfObject):
     async def manage(self, logger: kopf.ObjectLogger) -> None:
         from resourcepool import ResourcePool
         resource_pool = await ResourcePool.get(self.resource_pool_name)
+        if not resource_pool:
+            resource_pool = await ResourcePool.fetch(name=name, namespace=Poolboy.namespace)
         if 'ownerReferences' not in self.metadata:
             await self.json_patch([{
                 "op": "add",

--- a/operator/resourcepoolscaling.py
+++ b/operator/resourcepoolscaling.py
@@ -17,6 +17,7 @@ ResourcePoolScalingT = TypeVar('ResourcePoolScalingT', bound='ResourcePoolScalin
 class ResourcePoolScaling(KopfObject):
     api_group = Poolboy.operator_domain
     api_version = Poolboy.operator_version
+    api_group_version = f"{api_group}/{api_version}"
     kind = "ResourcePoolScaling"
     plural = "resourcepoolscalings"
 

--- a/operator/resourcewatch.py
+++ b/operator/resourcewatch.py
@@ -31,6 +31,7 @@ ResourceWatchT = TypeVar('ResourceWatchT', bound='ResourceWatch')
 class ResourceWatch(KopfObject):
     api_group = Poolboy.operator_domain
     api_version = Poolboy.operator_version
+    api_group_version = f"{api_group}/{api_version}"
     kind = "ResourceWatch"
     plural = "resourcewatches"
 

--- a/run-local.sh
+++ b/run-local.sh
@@ -24,7 +24,7 @@ if [[ -d venv ]]; then
 else
   python -m venv ./venv
   . ./venv/bin/activate
-  pip install git+https://github.com/rhpds/kopf.git@add-deprecated-finalizer-support
+  pip install git+https://github.com/rhpds/kopf.git@add-label-selector
   pip install -r dev-requirements.txt
   pip install -r requirements.txt
 fi

--- a/test/roles/poolboy_test_simple/tasks/test-finalizers-01.yaml
+++ b/test/roles/poolboy_test_simple/tasks/test-finalizers-01.yaml
@@ -114,33 +114,6 @@
       r_get_resource_handle.resources[0].metadata.finalizers != [poolboy_domain ~ '/handler']
     )
 
-- name: Set deprecated finalizer on ResourceHandle for test-finalizers-01-a
-  kubernetes.core.k8s:
-    api_version: "{{ poolboy_domain }}/v1"
-    kind: ResourceHandle
-    name: "{{ resource_claim_test_finalizers_01_a_resource_handle_name }}"
-    namespace: "{{ poolboy_namespace }}"
-    definition:
-      metadata:
-        finalizers: >-
-          {{ [poolboy_domain ~ '/handler-9'] }}
-
-- name: Pause 2 seconds
-  ansible.builtin.pause:
-    seconds: 2
-
-- name: Verify finalizers on ResourceHandle for test-finalizers-01-a
-  kubernetes.core.k8s_info:
-    api_version: "{{ poolboy_domain }}/v1"
-    kind: ResourceHandle
-    name: "{{ resource_claim_test_finalizers_01_a_resource_handle_name }}"
-    namespace: "{{ poolboy_namespace }}"
-  register: r_get_resource_handle
-  failed_when: >-
-    r_get_resource_handle.resources | length != 1 or
-    r_get_resource_handle.resources[0].metadata.finalizers is undefined or
-    r_get_resource_handle.resources[0].metadata.finalizers != [poolboy_domain ~ '/handler-9']
-
 - name: Delete ResourceClaim test-finalizers-01-a
   kubernetes.core.k8s:
     api_version: "{{ poolboy_domain }}/v1"


### PR DESCRIPTION
- Clean up and standardize `api_group_version`
- Standardize `refetch()` to throw exception
- Add cache clean for watching other resource handler
- Fix missing return in resource count comparison
- Add test on bind ResourceHandle to ResourceClaim to ensure no double-binding
- Fix ResourcePoolScaling issue when ResourcePool is not in cache
- Remove deprecated finalizer support