### PR TITLE
fix: NameError in ResourcePoolScaling.manage() fallback path

### DIFF
--- a/operator/resourcepoolscaling.py
+++ b/operator/resourcepoolscaling.py
@@ -102,7 +102,7 @@ class ResourcePoolScaling(KopfObject):
         from resourcepool import ResourcePool
         resource_pool = await ResourcePool.get(self.resource_pool_name)
         if not resource_pool:
-            resource_pool = await ResourcePool.fetch(name=name, namespace=Poolboy.namespace)
+            resource_pool = await ResourcePool.fetch(name=self.resource_pool_name, namespace=Poolboy.namespace)
         if 'ownerReferences' not in self.metadata:
             await self.json_patch([{
                 "op": "add",


### PR DESCRIPTION
## Summary
- Fix undefined variable `name` → `self.resource_pool_name` in `ResourcePoolScaling.manage()` line 105

## Problem
When `ResourcePool.get()` returns `None` (cache miss), the fallback fetch on line 105 references an undefined variable `name`:

```python
resource_pool = await ResourcePool.fetch(name=name, namespace=Poolboy.namespace)
```

This raises `NameError: name 'name' is not defined` and crashes the handler on every retry (60s interval). All `ResourcePoolScaling` operations are blocked, preventing shared cluster pools from scaling up.

**Impact on production (ocp-us-west-2):** 4 ResourcePoolScaling objects stuck in `waiting` state with 1,050+ retries, blocking pool provisioning for multiple Summit 2026 labs.

## Fix
```diff
-            resource_pool = await ResourcePool.fetch(name=name, namespace=Poolboy.namespace)
+            resource_pool = await ResourcePool.fetch(name=self.resource_pool_name, namespace=Poolboy.namespace)
```

## Why it wasn't caught earlier
The bug is on a fallback path — `ResourcePool.get()` on line 103 normally succeeds from the in-memory cache, so line 105 is rarely reached. It only triggers when the cache misses, e.g., after operator restart or when a new ResourcePoolScaling is created before the ResourcePool is cached.