### PR TITLE
Fix restrictive lifespan value pattern

### DIFF
--- a/helm/crds/resourceclaims.yaml
+++ b/helm/crds/resourceclaims.yaml
@@ -204,14 +204,14 @@ spec:
                       Configured as a whole number followed by units "s", "m", "h", or "d" for seconds, minutes, hours, or days.
                       Ex: "3d" for 3 days.
                     type: string
-                    pattern: ^[0-9]+[smhd]$
+                    pattern: ^([0-9]+[smhd])+$
                   relativeMaximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the present datetime.
                       Configured as a whole number followed by units "s", "m", "h", or "d" for seconds, minutes, hours, or days.
                       Ex: "3d" for 3 days.
                     type: string
-                    pattern: ^[0-9]+[smhd]$
+                    pattern: ^([0-9]+[smhd])+$
                   start:
                     description: >-
                       Effective timestamp for start of lifespan for ResourceClaim.

--- a/helm/crds/resourcehandles.yaml
+++ b/helm/crds/resourcehandles.yaml
@@ -78,6 +78,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   end:
                     description: >-
                       Configured end of lifespan for ResourceHandle and resources it manages.
@@ -90,6 +91,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   relativeMaximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the present datetime.
@@ -97,6 +99,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
               preferenceScore:
                 description: >-
                   The preference score is used to compare otherwise equivalent ResourceHandles

--- a/helm/crds/resourcepools.yaml
+++ b/helm/crds/resourcepools.yaml
@@ -73,6 +73,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   maximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the creation timestamp of the ResourceClaim.
@@ -80,6 +81,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   relativeMaximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the present datetime.
@@ -87,13 +89,14 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   unclaimed:
                     description: >-
                       Lifespan applied to ResourceHandles in the pool to allow for replacement of unused resources.
                       Configured as a whole number followed by units "s", "m", "h", or "d" for seconds, minutes, hours, or days.
                       Ex: "3d" for 3 days.
                     type: string
-                    pattern: ^[0-9]+[smhd]$
+                    pattern: ^([0-9]+[smhd])+$
               maxUnready:
                 description: >-
                   Maximum number of resource handles that do not pass readiness check.

--- a/helm/templates/crds/resourceclaims.yaml
+++ b/helm/templates/crds/resourceclaims.yaml
@@ -205,14 +205,14 @@ spec:
                       Configured as a whole number followed by units "s", "m", "h", or "d" for seconds, minutes, hours, or days.
                       Ex: "3d" for 3 days.
                     type: string
-                    pattern: ^[0-9]+[smhd]$
+                    pattern: ^([0-9]+[smhd])+$
                   relativeMaximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the present datetime.
                       Configured as a whole number followed by units "s", "m", "h", or "d" for seconds, minutes, hours, or days.
                       Ex: "3d" for 3 days.
                     type: string
-                    pattern: ^[0-9]+[smhd]$
+                    pattern: ^([0-9]+[smhd])+$
                   start:
                     description: >-
                       Effective timestamp for start of lifespan for ResourceClaim.

--- a/helm/templates/crds/resourcehandles.yaml
+++ b/helm/templates/crds/resourcehandles.yaml
@@ -79,6 +79,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   end:
                     description: >-
                       Configured end of lifespan for ResourceHandle and resources it manages.
@@ -91,6 +92,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   relativeMaximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the present datetime.
@@ -98,6 +100,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
               preferenceScore:
                 description: >-
                   The preference score to apply to ResourceHandles created from this ResourcePool.

--- a/helm/templates/crds/resourcepools.yaml
+++ b/helm/templates/crds/resourcepools.yaml
@@ -74,6 +74,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   maximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the creation timestamp of the ResourceClaim.
@@ -81,6 +82,7 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   relativeMaximum:
                     description: >-
                       Maximum lifespan which may be requested in the ResourceClaim relative to the present datetime.
@@ -88,13 +90,14 @@ spec:
                       Ex: "3d" for 3 days.
                       This value may be a template string.
                     type: string
+                    pattern: ^([0-9]+[smhd])+$
                   unclaimed:
                     description: >-
                       Lifespan applied to ResourceHandles in the pool to allow for replacement of unused resources.
                       Configured as a whole number followed by units "s", "m", "h", or "d" for seconds, minutes, hours, or days.
                       Ex: "3d" for 3 days.
                     type: string
-                    pattern: ^[0-9]+[smhd]$
+                    pattern: ^([0-9]+[smhd])+$
               maxUnready:
                 description: >-
                   Maximum number of resource handles that do not pass readiness check.


### PR DESCRIPTION
Poolboy supports lifespan values with multiple time unit specifications but the CRDs were preventing this use.