### PR TITLE
Block resource creation when linked ResourceProvider not found in handle

### DIFF
--- a/operator/resourcehandle.py
+++ b/operator/resourcehandle.py
@@ -1354,12 +1354,23 @@ class ResourceHandle(KopfObject):
                             linked_resource_state = resource_states[pn]
                             break
                     else:
-                        logger.debug(
-                            f"{self} uses {resource_provider} which has "
-                            f"linked ResourceProvider {resource_provider.name} but no resource in this "
-                            f"ResourceHandle uses this provider."
-                        )
-                        continue
+                        if not linked_provider.when:
+                            logger.warning(
+                                f"{self} uses {resource_provider} which has "
+                                f"linked ResourceProvider {linked_provider.name} "
+                                f"(resource name: {linked_provider.resource_name}) "
+                                f"but no resource in this ResourceHandle uses this "
+                                f"provider. Blocking resource creation."
+                            )
+                            wait_for_linked_provider = True
+                            break
+                        else:
+                            logger.debug(
+                                f"{self} uses {resource_provider} which has "
+                                f"linked ResourceProvider {linked_provider.name} "
+                                f"with when condition - skipping."
+                            )
+                            continue
 
                     if not linked_provider.check_wait_for(
                         linked_resource_provider = linked_resource_provider,


### PR DESCRIPTION
## Summary

- When `linkedResourceProviders` defines a `waitFor` condition and the linked resource is not found in the ResourceHandle, the `manage()` loop was silently skipping the check via `continue` in the `for...else` branch
- This allowed dependent resources (e.g., workload AnarchySubjects) to be created before their linked resources (e.g., cluster) were ready, causing provision failures
- Now blocks resource creation (`wait_for_linked_provider = True`) when the linked resource is missing and no `when` condition explains its absence
- Preserves existing behavior for linked providers with `when` conditions (conditional exclusion is expected)

## Problem

ResourceProvider configs like:

```yaml
linkedResourceProviders:
- name: cluster-provider
  waitFor: current_state_0 == 'started'
  templateVars:
  - name: current_state_0
    from: /spec/vars/current_state
```

...were not blocking the dependent resource. The workload provision fired immediately, failing with undefined variable errors because the cluster wasn't ready yet.

## Root cause

In `ResourceHandle.manage()` (resourcehandle.py ~line 1356), the `for...else` block that searches for the linked resource in the handle hit the `else` branch and called `continue`, skipping to the next linked provider without setting `wait_for_linked_provider = True`.

## Test plan

- [ ] Existing `test-linked-01` through `test-linked-03` pass (no regression)
- [ ] Manual test: create a multi-resource claim with `waitFor` on a linked provider, verify dependent resource shows `waitingFor: "Linked ResourceProvider"` until the linked resource is ready
- [ ] Verify `when`-conditioned linked providers still work correctly (test-linked-03)

Fixes RHDPOPS-23813.